### PR TITLE
Remove broken funvas from demo

### DIFF
--- a/funvas_demo/lib/factories/animations.dart
+++ b/funvas_demo/lib/factories/animations.dart
@@ -9,7 +9,6 @@ final funvasFactories = <FunvasFactory<FunvasTweetMixin>>[
   FunvasFactory(() => Two()),
   FunvasFactory(() => Six()),
   FunvasFactory(() => Five()),
-  FunvasFactory(() => Ten()),
 ];
 
 /// Funvas factory for a WIP funvas that has no associated tweet yet.


### PR DESCRIPTION
The avatar funvas is broken in the demo because there is a Flutter web bug that makes it look weird.

https://github.com/flutter/flutter/issues/73120