### PR TITLE
Remove `dev` channel from CI

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -15,7 +15,6 @@ jobs:
         channel:
           - 'stable'
           - 'beta'
-          - 'dev'
           - 'master'
         package:
           - 'funvas'
@@ -49,7 +48,6 @@ jobs:
         channel:
           - 'stable'
           - 'beta'
-          - 'dev'
           - 'master'
         package:
           #          todo: add test coverage to funvas packages.


### PR DESCRIPTION
The `dev` channel has been discontinued by Flutter. See https://medium.com/flutter/whats-new-in-flutter-2-8-d085b763d181#34c4.